### PR TITLE
PR: develop, Remove bound check during auto scrolling

### DIFF
--- a/JSReorderableCollectionView/JSReorderableCollectionView/JSReorderableCollectionView.swift
+++ b/JSReorderableCollectionView/JSReorderableCollectionView/JSReorderableCollectionView.swift
@@ -180,17 +180,7 @@ open class JSReorderableCollectionView: UICollectionView {
         scrollWeight = calcScrollWeightFromPoint(point, axis: scrollDirection, threshold: scrollThreshold)
         if scrollWeight > 0 {
             // Need auto scroll
-            if scrollDirection == .horizontal {
-                if contentOffset.x >= startBound && contentOffset.x <= endBound {
-                    // Check offset bound
-                    addScrollDisplayLink()
-                }
-            } else {
-                if contentOffset.y >= startBound && contentOffset.y <= endBound {
-                    // Check offset bound
-                    addScrollDisplayLink()
-                }
-            }
+            addScrollDisplayLink()
         } else {
             // Invalidate display link if auto scroll not need at point
             invalidateScrollDisplayLink()


### PR DESCRIPTION
# Change log
- Remove bound check during auto scrolling

# Dsecription
### AS-IS
```swift
private func checkPointToScroll() {
    ...
    if scrollWeight > 0 {
        if scrollDirection == .horizontal {
            if contentOffset.x >= startBound && contentOffset.x <= endBound {
                addScrollDisplayLink()
            }
        }
        ...
    }
    ...
}
```

### TO-BE
```swift
private func checkPointToScroll() {
    ...
    if scrollWeight > 0 {
        addScrollDisplayLink()
    }
    ...
}
```

This condition is meaningless in auto scroll process. because content offset be in bound range. So this condition will be true always. (but modify reason isn't this 😅)

When touch collection view's edges to scroll, It call display link -> handler -> invalidate display link every time.
```swift
contentOffset.x >= startBound && contentOffset.x <= endBound
```

# Discussion
I set content offset using `min`, `max` to adjust value during auto scrolling. but offset value is out of my expect sometimes...

I think that remove bound check condition is way to solve this problem. So modified it.